### PR TITLE
Change FindClosestObject so it must be on object.

### DIFF
--- a/SpeechSandbox/Assets/Scripts/GameManager.cs
+++ b/SpeechSandbox/Assets/Scripts/GameManager.cs
@@ -94,7 +94,7 @@ public class GameManager : MonoBehaviour {
         {
             Vector3 diff = go.transform.position - position;
             float curDistance = diff.sqrMagnitude;
-            if (curDistance < distance)
+            if (curDistance < distance && curDistance < 1.0)
             {
                 closest = go;
                 distance = curDistance;


### PR DESCRIPTION
Add a test to the FindClosestObject() method so that the
reticle pointer must be within 1.0 relative units from the
object, effictively requiring that it point to the object.