### PR TITLE
Removing references to Asset Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ To find the `WORKSPACE_ID` for Watson Assistant:
 cd SpeechSandbox/Assets
 ```
 
-* Either download the Watson Unity SDK from the Unity asset store or perform the following:
+* Download the [Watson SDK for Unity](https://github.com/watson-developer-cloud/unity-sdk) or perform the following:
 
 ```bash
 git clone https://github.com/watson-developer-cloud/unity-sdk.git
 ```
 
-For the github version make sure you are on the develop branch.
+Make sure you are on the develop branch.
 1. Open Unity and inside the project launcher select the ![Open](doc/source/images/unity_open.png?raw=true) button.
 1. Navigate to where you cloned this repository and open the `Creation Sandbox` directory.
 1. If prompted to upgrade the project to a newer Unity version, do so.


### PR DESCRIPTION
Reflecting the removal of the Watson SDK for Unity from the asset store on Dec 31, 2018.

Only the English version is changed in this PR.